### PR TITLE
Made region available in regionalStackBuilder

### DIFF
--- a/lib/src/global-cloud.ts
+++ b/lib/src/global-cloud.ts
@@ -49,7 +49,7 @@ export abstract class GlobalCloud {
         scope,
         id + region.toUpperCase() + this.stage.name + 'Stack',
         {
-          builder: this.regionalStackBuilder(),
+          builder: this.regionalStackBuilder(region),
           env: {
             account: this.stage.account,
             region,
@@ -65,5 +65,5 @@ export abstract class GlobalCloud {
 
   abstract globalStackBuilder(): (scope: Stack) => void;
 
-  abstract regionalStackBuilder(): (scope: Stack) => void;
+  abstract regionalStackBuilder(region: Region): (scope: Stack) => void;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cdk-global-cloud",
-  "version": "0.0.2-alpha",
+  "version": "0.0.3-alpha",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cdk-global-cloud",
-      "version": "0.0.2-alpha",
+      "version": "0.0.3-alpha",
       "license": "MIT",
       "dependencies": {
         "aws-cdk-lib": "^2.60.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cdk-global-cloud",
   "description": "An opinionated CDK library for deploying global cloud infrastructures.",
-  "version": "0.0.2-alpha",
+  "version": "0.0.3-alpha",
   "license": "MIT",
   "author": "Sachin Shekhar",
   "main": "dist/index.js",

--- a/tests/__snapshots__/api-global-cloud.test.ts.snap
+++ b/tests/__snapshots__/api-global-cloud.test.ts.snap
@@ -990,6 +990,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
     "ApiHandler5E7490E8": {
       "DependsOn": [
         "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "ApiHandlerServiceRoleOverflowPolicy147BA3B1F",
         "ApiHandlerServiceRole592E70E9",
       ],
       "Properties": {
@@ -1398,6 +1399,372 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "ApiHandlerServiceRoleOverflowPolicy147BA3B1F": {
+      "Properties": {
+        "Description": "Part of the policies for APIUS-EAST-1DevStack/ApiHandler/ServiceRole",
+        "Path": "/",
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "dynamodb:DeleteItem",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-2:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-1:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-2:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-1:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-2:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ca-central-1:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-1:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-2:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-north-1:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-1:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-3:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-1:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-2:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-1:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-2:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-1:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-2:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-3:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-1:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-2:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-3:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:me-central-1:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Roles": [
+          {
+            "Ref": "ApiHandlerServiceRole592E70E9",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::ManagedPolicy",
+    },
+    "ApiHandlersesSendEmail726F8BB3": {
+      "Properties": {
+        "Action": "ses:SendEmail",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "ApiHandler5E7490E8",
+            "Arn",
+          ],
+        },
+        "Principal": "ses.amazonaws.com",
+      },
+      "Type": "AWS::Lambda::Permission",
     },
   },
   "Rules": {


### PR DESCRIPTION
This PR adds region to the scope of regionalStackBuilder using which certain constructs can be conditionally built. It can be useful when a service isn't available in all regions targeted by a GlobalCloud.