### PR TITLE
Beautified generated regional stack name

### DIFF
--- a/lib/src/global-cloud.ts
+++ b/lib/src/global-cloud.ts
@@ -1,6 +1,6 @@
 import { App, Stack } from 'aws-cdk-lib';
 
-import { Region } from './region';
+import { getRegionName, Region } from './region';
 import { GlobalCloudStack } from './stack';
 import { Stage } from './stage';
 
@@ -47,7 +47,7 @@ export abstract class GlobalCloud {
     this.regionalCoverage.forEach((region) => {
       const regionalStack = new GlobalCloudStack(
         scope,
-        id + region.toUpperCase() + this.stage.name + 'Stack',
+        id + getRegionName(region) + this.stage.name + 'Stack',
         {
           builder: this.regionalStackBuilder(region),
           env: {

--- a/lib/src/region.ts
+++ b/lib/src/region.ts
@@ -96,3 +96,36 @@ export class Regions {
 
   static readonly GOVERNMENT: Region[] = ['us-gov-east-1', 'us-gov-west-1'];
 }
+
+export function getRegionName(region: Region): string {
+  return (<{ [K in Region]: string }>{
+    'us-east-1': 'NorthVirginia',
+    'us-east-2': 'Ohio',
+    'us-west-1': 'NorthCalifornia',
+    'us-west-2': 'Oregon',
+    'ca-central-1': 'Canada',
+    'eu-central-1': 'Frankfurt',
+    'eu-central-2': 'Zurich',
+    'eu-north-1': 'Stockholm',
+    'eu-west-1': 'Ireland',
+    'eu-west-2': 'London',
+    'eu-west-3': 'Paris',
+    'eu-south-1': 'Milan',
+    'eu-south-2': 'Spain',
+    'ap-east-1': 'HongKong',
+    'ap-south-1': 'Mumbai',
+    'ap-south-2': 'Hyderabad',
+    'ap-southeast-1': 'Singapore',
+    'ap-southeast-2': 'Sydney',
+    'ap-southeast-3': 'Jakarta',
+    'ap-northeast-1': 'Tokyo',
+    'ap-northeast-2': 'Seoul',
+    'ap-northeast-3': 'Osaka',
+    'sa-east-1': 'SaoPaulo',
+    'me-central-1': 'UAE',
+    'me-south-1': 'Bahrain',
+    'af-south-1': 'CapeTown',
+    'us-gov-east-1': 'USGovCloudEast',
+    'us-gov-west-1': 'USGovCloudWest',
+  })[region];
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cdk-global-cloud",
-  "version": "0.0.3-alpha",
+  "version": "0.0.4-alpha",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cdk-global-cloud",
-      "version": "0.0.3-alpha",
+      "version": "0.0.4-alpha",
       "license": "MIT",
       "dependencies": {
         "aws-cdk-lib": "^2.60.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cdk-global-cloud",
   "description": "An opinionated CDK library for deploying global cloud infrastructures.",
-  "version": "0.0.3-alpha",
+  "version": "0.0.4-alpha",
   "license": "MIT",
   "author": "Sachin Shekhar",
   "main": "dist/index.js",

--- a/tests/__snapshots__/api-global-cloud.test.ts.snap
+++ b/tests/__snapshots__/api-global-cloud.test.ts.snap
@@ -1402,7 +1402,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
     },
     "ApiHandlerServiceRoleOverflowPolicy147BA3B1F": {
       "Properties": {
-        "Description": "Part of the policies for APIUS-EAST-1DevStack/ApiHandler/ServiceRole",
+        "Description": "Part of the policies for APINorthVirginiaDevStack/ApiHandler/ServiceRole",
         "Path": "/",
         "PolicyDocument": {
           "Statement": [


### PR DESCRIPTION
This PR beautifies generated regional stack name. Instead of using region code, it now uses official human readable name of the region.