### PR TITLE
Region-specific accounts in Stage

### DIFF
--- a/examples/multi-region-serverless/index.ts
+++ b/examples/multi-region-serverless/index.ts
@@ -1,6 +1,6 @@
 import * as cdk from 'aws-cdk-lib';
 
-import { Stage } from '../../lib';
+import { Regions, Stage } from '../../lib';
 import { ApiGlobalCloud } from './api-global-cloud';
 
 const app = new cdk.App();
@@ -19,10 +19,15 @@ new ApiGlobalCloud(
   })
 );
 
-new ApiGlobalCloud(
+export const prodAPICloud = new ApiGlobalCloud(
   app,
   new Stage('Prod', {
     account: '9876543210', // process.env can be used if you don't want to include this in your source control
+    regionalAccounts: {
+      ...Regions.EUROPE.map((region) => ({ [region]: '364572292763' })),
+      'ap-south-1': '877347237637',
+      'eu-west-1': '655435786756',
+    },
     terminationProtection: true,
   })
 );

--- a/lib/src/global-cloud.ts
+++ b/lib/src/global-cloud.ts
@@ -51,7 +51,8 @@ export abstract class GlobalCloud {
         {
           builder: this.regionalStackBuilder(region),
           env: {
-            account: this.stage.account,
+            account:
+              this.stage.regionalAccounts?.[region] ?? this.stage.account,
             region,
           },
           tags,

--- a/lib/src/stage.ts
+++ b/lib/src/stage.ts
@@ -2,14 +2,14 @@ import { Region } from './region';
 
 export interface StageProps {
   account: string;
-  regionalAccounts?: { [region in Region]: string };
+  regionalAccounts?: { [region in Region]?: string };
   terminationProtection?: boolean;
 }
 
 export class Stage {
   readonly name: string;
   readonly account: string;
-  readonly regionalAccounts?: { [region in Region]: string };
+  readonly regionalAccounts?: { [region in Region]?: string };
   readonly terminationProtection: boolean;
 
   constructor(name: string, props: StageProps) {

--- a/lib/src/stage.ts
+++ b/lib/src/stage.ts
@@ -1,16 +1,21 @@
+import { Region } from './region';
+
 export interface StageProps {
   account: string;
+  regionalAccounts?: { [region in Region]: string };
   terminationProtection?: boolean;
 }
 
 export class Stage {
   readonly name: string;
   readonly account: string;
+  readonly regionalAccounts?: { [region in Region]: string };
   readonly terminationProtection: boolean;
 
   constructor(name: string, props: StageProps) {
     this.name = name;
     this.account = props.account;
+    this.regionalAccounts = props.regionalAccounts;
     this.terminationProtection = props.terminationProtection ?? false;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cdk-global-cloud",
-  "version": "0.0.5-alpha",
+  "version": "0.0.6-alpha",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cdk-global-cloud",
-      "version": "0.0.5-alpha",
+      "version": "0.0.6-alpha",
       "license": "MIT",
       "dependencies": {
         "aws-cdk-lib": "^2.60.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cdk-global-cloud",
   "description": "An opinionated CDK library for deploying global cloud infrastructures.",
-  "version": "0.0.5-alpha",
+  "version": "0.0.6-alpha",
   "license": "MIT",
   "author": "Sachin Shekhar",
   "main": "dist/index.js",

--- a/tests/__snapshots__/api-global-cloud.test.ts.snap
+++ b/tests/__snapshots__/api-global-cloud.test.ts.snap
@@ -5,7 +5,7 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
   "Outputs": {
     "ExportsOutputFnGetAttDataTable447BC44EArnA4C585D9": {
       "Export": {
-        "Name": "APIGlobalDevStack:ExportsOutputFnGetAttDataTable447BC44EArnA4C585D9",
+        "Name": "APIGlobalProdStack:ExportsOutputFnGetAttDataTable447BC44EArnA4C585D9",
       },
       "Value": {
         "Fn::GetAtt": [
@@ -16,7 +16,7 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
     },
     "ExportsOutputRefDataTable447BC44E7F3657BE": {
       "Export": {
-        "Name": "APIGlobalDevStack:ExportsOutputRefDataTable447BC44E7F3657BE",
+        "Name": "APIGlobalProdStack:ExportsOutputRefDataTable447BC44E7F3657BE",
       },
       "Value": {
         "Ref": "DataTable447BC44E",
@@ -50,7 +50,7 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
         "StreamSpecification": {
           "StreamViewType": "NEW_AND_OLD_IMAGES",
         },
-        "TableName": "apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+        "TableName": "apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
       },
       "Type": "AWS::DynamoDB::Table",
       "UpdateReplacePolicy": "Retain",
@@ -59,15 +59,15 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
       "DeletionPolicy": "Delete",
       "DependsOn": [
         "DataTableReplicaapsoutheast3ACB22189",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleFA19674014C5BA32",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRole9AC6F94BB7CC2633",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleBB765236DD5B1553",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRoleFB7188DD8C9B1DB0",
       ],
       "Properties": {
         "Region": "ap-northeast-1",
         "ServiceToken": {
           "Fn::GetAtt": [
             "awscdkawsdynamodbReplicaProviderNestedStackawscdkawsdynamodbReplicaProviderNestedStackResource18E3F12D",
-            "Outputs.APIGlobalDevStackawscdkawsdynamodbReplicaProviderframeworkonEvent22C0CFD1Arn",
+            "Outputs.APIGlobalProdStackawscdkawsdynamodbReplicaProviderframeworkonEvent8CEABAFEArn",
           ],
         },
         "TableName": {
@@ -81,15 +81,15 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
       "DeletionPolicy": "Delete",
       "DependsOn": [
         "DataTableReplicaapnortheast1F85B661A",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleFA19674014C5BA32",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRole9AC6F94BB7CC2633",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleBB765236DD5B1553",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRoleFB7188DD8C9B1DB0",
       ],
       "Properties": {
         "Region": "ap-northeast-2",
         "ServiceToken": {
           "Fn::GetAtt": [
             "awscdkawsdynamodbReplicaProviderNestedStackawscdkawsdynamodbReplicaProviderNestedStackResource18E3F12D",
-            "Outputs.APIGlobalDevStackawscdkawsdynamodbReplicaProviderframeworkonEvent22C0CFD1Arn",
+            "Outputs.APIGlobalProdStackawscdkawsdynamodbReplicaProviderframeworkonEvent8CEABAFEArn",
           ],
         },
         "TableName": {
@@ -103,15 +103,15 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
       "DeletionPolicy": "Delete",
       "DependsOn": [
         "DataTableReplicaapnortheast218A5E5E8",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleFA19674014C5BA32",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRole9AC6F94BB7CC2633",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleBB765236DD5B1553",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRoleFB7188DD8C9B1DB0",
       ],
       "Properties": {
         "Region": "ap-northeast-3",
         "ServiceToken": {
           "Fn::GetAtt": [
             "awscdkawsdynamodbReplicaProviderNestedStackawscdkawsdynamodbReplicaProviderNestedStackResource18E3F12D",
-            "Outputs.APIGlobalDevStackawscdkawsdynamodbReplicaProviderframeworkonEvent22C0CFD1Arn",
+            "Outputs.APIGlobalProdStackawscdkawsdynamodbReplicaProviderframeworkonEvent8CEABAFEArn",
           ],
         },
         "TableName": {
@@ -125,15 +125,15 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
       "DeletionPolicy": "Delete",
       "DependsOn": [
         "DataTableReplicaeusouth2515F6EAD",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleFA19674014C5BA32",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRole9AC6F94BB7CC2633",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleBB765236DD5B1553",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRoleFB7188DD8C9B1DB0",
       ],
       "Properties": {
         "Region": "ap-south-1",
         "ServiceToken": {
           "Fn::GetAtt": [
             "awscdkawsdynamodbReplicaProviderNestedStackawscdkawsdynamodbReplicaProviderNestedStackResource18E3F12D",
-            "Outputs.APIGlobalDevStackawscdkawsdynamodbReplicaProviderframeworkonEvent22C0CFD1Arn",
+            "Outputs.APIGlobalProdStackawscdkawsdynamodbReplicaProviderframeworkonEvent8CEABAFEArn",
           ],
         },
         "TableName": {
@@ -147,15 +147,15 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
       "DeletionPolicy": "Delete",
       "DependsOn": [
         "DataTableReplicaapsouth1C90A74EF",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleFA19674014C5BA32",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRole9AC6F94BB7CC2633",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleBB765236DD5B1553",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRoleFB7188DD8C9B1DB0",
       ],
       "Properties": {
         "Region": "ap-south-2",
         "ServiceToken": {
           "Fn::GetAtt": [
             "awscdkawsdynamodbReplicaProviderNestedStackawscdkawsdynamodbReplicaProviderNestedStackResource18E3F12D",
-            "Outputs.APIGlobalDevStackawscdkawsdynamodbReplicaProviderframeworkonEvent22C0CFD1Arn",
+            "Outputs.APIGlobalProdStackawscdkawsdynamodbReplicaProviderframeworkonEvent8CEABAFEArn",
           ],
         },
         "TableName": {
@@ -169,15 +169,15 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
       "DeletionPolicy": "Delete",
       "DependsOn": [
         "DataTableReplicaapsouth2FA578A16",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleFA19674014C5BA32",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRole9AC6F94BB7CC2633",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleBB765236DD5B1553",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRoleFB7188DD8C9B1DB0",
       ],
       "Properties": {
         "Region": "ap-southeast-1",
         "ServiceToken": {
           "Fn::GetAtt": [
             "awscdkawsdynamodbReplicaProviderNestedStackawscdkawsdynamodbReplicaProviderNestedStackResource18E3F12D",
-            "Outputs.APIGlobalDevStackawscdkawsdynamodbReplicaProviderframeworkonEvent22C0CFD1Arn",
+            "Outputs.APIGlobalProdStackawscdkawsdynamodbReplicaProviderframeworkonEvent8CEABAFEArn",
           ],
         },
         "TableName": {
@@ -191,15 +191,15 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
       "DeletionPolicy": "Delete",
       "DependsOn": [
         "DataTableReplicaapsoutheast11A3D4E48",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleFA19674014C5BA32",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRole9AC6F94BB7CC2633",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleBB765236DD5B1553",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRoleFB7188DD8C9B1DB0",
       ],
       "Properties": {
         "Region": "ap-southeast-2",
         "ServiceToken": {
           "Fn::GetAtt": [
             "awscdkawsdynamodbReplicaProviderNestedStackawscdkawsdynamodbReplicaProviderNestedStackResource18E3F12D",
-            "Outputs.APIGlobalDevStackawscdkawsdynamodbReplicaProviderframeworkonEvent22C0CFD1Arn",
+            "Outputs.APIGlobalProdStackawscdkawsdynamodbReplicaProviderframeworkonEvent8CEABAFEArn",
           ],
         },
         "TableName": {
@@ -213,15 +213,15 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
       "DeletionPolicy": "Delete",
       "DependsOn": [
         "DataTableReplicaapsoutheast265B54B55",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleFA19674014C5BA32",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRole9AC6F94BB7CC2633",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleBB765236DD5B1553",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRoleFB7188DD8C9B1DB0",
       ],
       "Properties": {
         "Region": "ap-southeast-3",
         "ServiceToken": {
           "Fn::GetAtt": [
             "awscdkawsdynamodbReplicaProviderNestedStackawscdkawsdynamodbReplicaProviderNestedStackResource18E3F12D",
-            "Outputs.APIGlobalDevStackawscdkawsdynamodbReplicaProviderframeworkonEvent22C0CFD1Arn",
+            "Outputs.APIGlobalProdStackawscdkawsdynamodbReplicaProviderframeworkonEvent8CEABAFEArn",
           ],
         },
         "TableName": {
@@ -235,15 +235,15 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
       "DeletionPolicy": "Delete",
       "DependsOn": [
         "DataTableReplicauswest26F7D6E98",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleFA19674014C5BA32",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRole9AC6F94BB7CC2633",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleBB765236DD5B1553",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRoleFB7188DD8C9B1DB0",
       ],
       "Properties": {
         "Region": "ca-central-1",
         "ServiceToken": {
           "Fn::GetAtt": [
             "awscdkawsdynamodbReplicaProviderNestedStackawscdkawsdynamodbReplicaProviderNestedStackResource18E3F12D",
-            "Outputs.APIGlobalDevStackawscdkawsdynamodbReplicaProviderframeworkonEvent22C0CFD1Arn",
+            "Outputs.APIGlobalProdStackawscdkawsdynamodbReplicaProviderframeworkonEvent8CEABAFEArn",
           ],
         },
         "TableName": {
@@ -257,15 +257,15 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
       "DeletionPolicy": "Delete",
       "DependsOn": [
         "DataTableReplicacacentral142D6A8D2",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleFA19674014C5BA32",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRole9AC6F94BB7CC2633",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleBB765236DD5B1553",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRoleFB7188DD8C9B1DB0",
       ],
       "Properties": {
         "Region": "eu-central-1",
         "ServiceToken": {
           "Fn::GetAtt": [
             "awscdkawsdynamodbReplicaProviderNestedStackawscdkawsdynamodbReplicaProviderNestedStackResource18E3F12D",
-            "Outputs.APIGlobalDevStackawscdkawsdynamodbReplicaProviderframeworkonEvent22C0CFD1Arn",
+            "Outputs.APIGlobalProdStackawscdkawsdynamodbReplicaProviderframeworkonEvent8CEABAFEArn",
           ],
         },
         "TableName": {
@@ -279,15 +279,15 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
       "DeletionPolicy": "Delete",
       "DependsOn": [
         "DataTableReplicaeucentral19F2A8C89",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleFA19674014C5BA32",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRole9AC6F94BB7CC2633",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleBB765236DD5B1553",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRoleFB7188DD8C9B1DB0",
       ],
       "Properties": {
         "Region": "eu-central-2",
         "ServiceToken": {
           "Fn::GetAtt": [
             "awscdkawsdynamodbReplicaProviderNestedStackawscdkawsdynamodbReplicaProviderNestedStackResource18E3F12D",
-            "Outputs.APIGlobalDevStackawscdkawsdynamodbReplicaProviderframeworkonEvent22C0CFD1Arn",
+            "Outputs.APIGlobalProdStackawscdkawsdynamodbReplicaProviderframeworkonEvent8CEABAFEArn",
           ],
         },
         "TableName": {
@@ -301,15 +301,15 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
       "DeletionPolicy": "Delete",
       "DependsOn": [
         "DataTableReplicaeucentral251D569D7",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleFA19674014C5BA32",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRole9AC6F94BB7CC2633",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleBB765236DD5B1553",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRoleFB7188DD8C9B1DB0",
       ],
       "Properties": {
         "Region": "eu-north-1",
         "ServiceToken": {
           "Fn::GetAtt": [
             "awscdkawsdynamodbReplicaProviderNestedStackawscdkawsdynamodbReplicaProviderNestedStackResource18E3F12D",
-            "Outputs.APIGlobalDevStackawscdkawsdynamodbReplicaProviderframeworkonEvent22C0CFD1Arn",
+            "Outputs.APIGlobalProdStackawscdkawsdynamodbReplicaProviderframeworkonEvent8CEABAFEArn",
           ],
         },
         "TableName": {
@@ -323,15 +323,15 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
       "DeletionPolicy": "Delete",
       "DependsOn": [
         "DataTableReplicaeuwest329C340EB",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleFA19674014C5BA32",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRole9AC6F94BB7CC2633",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleBB765236DD5B1553",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRoleFB7188DD8C9B1DB0",
       ],
       "Properties": {
         "Region": "eu-south-1",
         "ServiceToken": {
           "Fn::GetAtt": [
             "awscdkawsdynamodbReplicaProviderNestedStackawscdkawsdynamodbReplicaProviderNestedStackResource18E3F12D",
-            "Outputs.APIGlobalDevStackawscdkawsdynamodbReplicaProviderframeworkonEvent22C0CFD1Arn",
+            "Outputs.APIGlobalProdStackawscdkawsdynamodbReplicaProviderframeworkonEvent8CEABAFEArn",
           ],
         },
         "TableName": {
@@ -345,15 +345,15 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
       "DeletionPolicy": "Delete",
       "DependsOn": [
         "DataTableReplicaeusouth15EDF7F8C",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleFA19674014C5BA32",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRole9AC6F94BB7CC2633",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleBB765236DD5B1553",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRoleFB7188DD8C9B1DB0",
       ],
       "Properties": {
         "Region": "eu-south-2",
         "ServiceToken": {
           "Fn::GetAtt": [
             "awscdkawsdynamodbReplicaProviderNestedStackawscdkawsdynamodbReplicaProviderNestedStackResource18E3F12D",
-            "Outputs.APIGlobalDevStackawscdkawsdynamodbReplicaProviderframeworkonEvent22C0CFD1Arn",
+            "Outputs.APIGlobalProdStackawscdkawsdynamodbReplicaProviderframeworkonEvent8CEABAFEArn",
           ],
         },
         "TableName": {
@@ -367,15 +367,15 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
       "DeletionPolicy": "Delete",
       "DependsOn": [
         "DataTableReplicaeunorth101DD4219",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleFA19674014C5BA32",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRole9AC6F94BB7CC2633",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleBB765236DD5B1553",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRoleFB7188DD8C9B1DB0",
       ],
       "Properties": {
         "Region": "eu-west-1",
         "ServiceToken": {
           "Fn::GetAtt": [
             "awscdkawsdynamodbReplicaProviderNestedStackawscdkawsdynamodbReplicaProviderNestedStackResource18E3F12D",
-            "Outputs.APIGlobalDevStackawscdkawsdynamodbReplicaProviderframeworkonEvent22C0CFD1Arn",
+            "Outputs.APIGlobalProdStackawscdkawsdynamodbReplicaProviderframeworkonEvent8CEABAFEArn",
           ],
         },
         "TableName": {
@@ -389,15 +389,15 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
       "DeletionPolicy": "Delete",
       "DependsOn": [
         "DataTableReplicaeuwest1AA092C67",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleFA19674014C5BA32",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRole9AC6F94BB7CC2633",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleBB765236DD5B1553",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRoleFB7188DD8C9B1DB0",
       ],
       "Properties": {
         "Region": "eu-west-3",
         "ServiceToken": {
           "Fn::GetAtt": [
             "awscdkawsdynamodbReplicaProviderNestedStackawscdkawsdynamodbReplicaProviderNestedStackResource18E3F12D",
-            "Outputs.APIGlobalDevStackawscdkawsdynamodbReplicaProviderframeworkonEvent22C0CFD1Arn",
+            "Outputs.APIGlobalProdStackawscdkawsdynamodbReplicaProviderframeworkonEvent8CEABAFEArn",
           ],
         },
         "TableName": {
@@ -411,15 +411,15 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
       "DeletionPolicy": "Delete",
       "DependsOn": [
         "DataTableReplicaapnortheast307421D9E",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleFA19674014C5BA32",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRole9AC6F94BB7CC2633",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleBB765236DD5B1553",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRoleFB7188DD8C9B1DB0",
       ],
       "Properties": {
         "Region": "me-central-1",
         "ServiceToken": {
           "Fn::GetAtt": [
             "awscdkawsdynamodbReplicaProviderNestedStackawscdkawsdynamodbReplicaProviderNestedStackResource18E3F12D",
-            "Outputs.APIGlobalDevStackawscdkawsdynamodbReplicaProviderframeworkonEvent22C0CFD1Arn",
+            "Outputs.APIGlobalProdStackawscdkawsdynamodbReplicaProviderframeworkonEvent8CEABAFEArn",
           ],
         },
         "TableName": {
@@ -432,15 +432,15 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
     "DataTableReplicauseast1F4B533DF": {
       "DeletionPolicy": "Delete",
       "DependsOn": [
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleFA19674014C5BA32",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRole9AC6F94BB7CC2633",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleBB765236DD5B1553",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRoleFB7188DD8C9B1DB0",
       ],
       "Properties": {
         "Region": "us-east-1",
         "ServiceToken": {
           "Fn::GetAtt": [
             "awscdkawsdynamodbReplicaProviderNestedStackawscdkawsdynamodbReplicaProviderNestedStackResource18E3F12D",
-            "Outputs.APIGlobalDevStackawscdkawsdynamodbReplicaProviderframeworkonEvent22C0CFD1Arn",
+            "Outputs.APIGlobalProdStackawscdkawsdynamodbReplicaProviderframeworkonEvent8CEABAFEArn",
           ],
         },
         "TableName": {
@@ -454,15 +454,15 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
       "DeletionPolicy": "Delete",
       "DependsOn": [
         "DataTableReplicauseast1F4B533DF",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleFA19674014C5BA32",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRole9AC6F94BB7CC2633",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleBB765236DD5B1553",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRoleFB7188DD8C9B1DB0",
       ],
       "Properties": {
         "Region": "us-east-2",
         "ServiceToken": {
           "Fn::GetAtt": [
             "awscdkawsdynamodbReplicaProviderNestedStackawscdkawsdynamodbReplicaProviderNestedStackResource18E3F12D",
-            "Outputs.APIGlobalDevStackawscdkawsdynamodbReplicaProviderframeworkonEvent22C0CFD1Arn",
+            "Outputs.APIGlobalProdStackawscdkawsdynamodbReplicaProviderframeworkonEvent8CEABAFEArn",
           ],
         },
         "TableName": {
@@ -476,15 +476,15 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
       "DeletionPolicy": "Delete",
       "DependsOn": [
         "DataTableReplicauseast22B50A567",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleFA19674014C5BA32",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRole9AC6F94BB7CC2633",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleBB765236DD5B1553",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRoleFB7188DD8C9B1DB0",
       ],
       "Properties": {
         "Region": "us-west-1",
         "ServiceToken": {
           "Fn::GetAtt": [
             "awscdkawsdynamodbReplicaProviderNestedStackawscdkawsdynamodbReplicaProviderNestedStackResource18E3F12D",
-            "Outputs.APIGlobalDevStackawscdkawsdynamodbReplicaProviderframeworkonEvent22C0CFD1Arn",
+            "Outputs.APIGlobalProdStackawscdkawsdynamodbReplicaProviderframeworkonEvent8CEABAFEArn",
           ],
         },
         "TableName": {
@@ -498,15 +498,15 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
       "DeletionPolicy": "Delete",
       "DependsOn": [
         "DataTableReplicauswest1EA64337D",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleFA19674014C5BA32",
-        "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRole9AC6F94BB7CC2633",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleBB765236DD5B1553",
+        "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRoleFB7188DD8C9B1DB0",
       ],
       "Properties": {
         "Region": "us-west-2",
         "ServiceToken": {
           "Fn::GetAtt": [
             "awscdkawsdynamodbReplicaProviderNestedStackawscdkawsdynamodbReplicaProviderNestedStackResource18E3F12D",
-            "Outputs.APIGlobalDevStackawscdkawsdynamodbReplicaProviderframeworkonEvent22C0CFD1Arn",
+            "Outputs.APIGlobalProdStackawscdkawsdynamodbReplicaProviderframeworkonEvent8CEABAFEArn",
           ],
         },
         "TableName": {
@@ -516,7 +516,7 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
       "Type": "Custom::DynamoDBReplica",
       "UpdateReplacePolicy": "Delete",
     },
-    "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleFA19674014C5BA32": {
+    "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleBB765236DD5B1553": {
       "Properties": {
         "Description": {
           "Fn::Join": [
@@ -554,14 +554,14 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
           {
             "Fn::GetAtt": [
               "awscdkawsdynamodbReplicaProviderNestedStackawscdkawsdynamodbReplicaProviderNestedStackResource18E3F12D",
-              "Outputs.APIGlobalDevStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRole181BF51ERef",
+              "Outputs.APIGlobalProdStackawscdkawsdynamodbReplicaProviderIsCompleteHandlerServiceRoleE584C4DDRef",
             ],
           },
         ],
       },
       "Type": "AWS::IAM::ManagedPolicy",
     },
-    "DataTableSourceTableAttachedManagedPolicyAPIGlobalDevStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRole9AC6F94BB7CC2633": {
+    "DataTableSourceTableAttachedManagedPolicyAPIGlobalProdStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRoleFB7188DD8C9B1DB0": {
       "Properties": {
         "Description": {
           "Fn::Join": [
@@ -604,7 +604,7 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:us-east-1:0123456789:table/",
+                      ":dynamodb:us-east-1:9876543210:table/",
                       {
                         "Ref": "DataTable447BC44E",
                       },
@@ -619,7 +619,7 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:us-east-2:0123456789:table/",
+                      ":dynamodb:us-east-2:9876543210:table/",
                       {
                         "Ref": "DataTable447BC44E",
                       },
@@ -634,7 +634,7 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:us-west-1:0123456789:table/",
+                      ":dynamodb:us-west-1:9876543210:table/",
                       {
                         "Ref": "DataTable447BC44E",
                       },
@@ -649,7 +649,7 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:us-west-2:0123456789:table/",
+                      ":dynamodb:us-west-2:9876543210:table/",
                       {
                         "Ref": "DataTable447BC44E",
                       },
@@ -664,7 +664,7 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:ca-central-1:0123456789:table/",
+                      ":dynamodb:ca-central-1:9876543210:table/",
                       {
                         "Ref": "DataTable447BC44E",
                       },
@@ -679,7 +679,7 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:eu-central-1:0123456789:table/",
+                      ":dynamodb:eu-central-1:9876543210:table/",
                       {
                         "Ref": "DataTable447BC44E",
                       },
@@ -694,7 +694,7 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:eu-central-2:0123456789:table/",
+                      ":dynamodb:eu-central-2:9876543210:table/",
                       {
                         "Ref": "DataTable447BC44E",
                       },
@@ -709,7 +709,7 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:eu-north-1:0123456789:table/",
+                      ":dynamodb:eu-north-1:9876543210:table/",
                       {
                         "Ref": "DataTable447BC44E",
                       },
@@ -724,7 +724,7 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:eu-west-1:0123456789:table/",
+                      ":dynamodb:eu-west-1:9876543210:table/",
                       {
                         "Ref": "DataTable447BC44E",
                       },
@@ -739,7 +739,7 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:eu-west-3:0123456789:table/",
+                      ":dynamodb:eu-west-3:9876543210:table/",
                       {
                         "Ref": "DataTable447BC44E",
                       },
@@ -754,7 +754,7 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:eu-south-1:0123456789:table/",
+                      ":dynamodb:eu-south-1:9876543210:table/",
                       {
                         "Ref": "DataTable447BC44E",
                       },
@@ -769,7 +769,7 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:eu-south-2:0123456789:table/",
+                      ":dynamodb:eu-south-2:9876543210:table/",
                       {
                         "Ref": "DataTable447BC44E",
                       },
@@ -784,7 +784,7 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:ap-south-1:0123456789:table/",
+                      ":dynamodb:ap-south-1:9876543210:table/",
                       {
                         "Ref": "DataTable447BC44E",
                       },
@@ -799,7 +799,7 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:ap-south-2:0123456789:table/",
+                      ":dynamodb:ap-south-2:9876543210:table/",
                       {
                         "Ref": "DataTable447BC44E",
                       },
@@ -814,7 +814,7 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:ap-southeast-1:0123456789:table/",
+                      ":dynamodb:ap-southeast-1:9876543210:table/",
                       {
                         "Ref": "DataTable447BC44E",
                       },
@@ -829,7 +829,7 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:ap-southeast-2:0123456789:table/",
+                      ":dynamodb:ap-southeast-2:9876543210:table/",
                       {
                         "Ref": "DataTable447BC44E",
                       },
@@ -844,7 +844,7 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:ap-southeast-3:0123456789:table/",
+                      ":dynamodb:ap-southeast-3:9876543210:table/",
                       {
                         "Ref": "DataTable447BC44E",
                       },
@@ -859,7 +859,7 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:ap-northeast-1:0123456789:table/",
+                      ":dynamodb:ap-northeast-1:9876543210:table/",
                       {
                         "Ref": "DataTable447BC44E",
                       },
@@ -874,7 +874,7 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:ap-northeast-2:0123456789:table/",
+                      ":dynamodb:ap-northeast-2:9876543210:table/",
                       {
                         "Ref": "DataTable447BC44E",
                       },
@@ -889,7 +889,7 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:ap-northeast-3:0123456789:table/",
+                      ":dynamodb:ap-northeast-3:9876543210:table/",
                       {
                         "Ref": "DataTable447BC44E",
                       },
@@ -904,7 +904,7 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:me-central-1:0123456789:table/",
+                      ":dynamodb:me-central-1:9876543210:table/",
                       {
                         "Ref": "DataTable447BC44E",
                       },
@@ -920,7 +920,7 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
           {
             "Fn::GetAtt": [
               "awscdkawsdynamodbReplicaProviderNestedStackawscdkawsdynamodbReplicaProviderNestedStackResource18E3F12D",
-              "Outputs.APIGlobalDevStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRole0EC35282Ref",
+              "Outputs.APIGlobalProdStackawscdkawsdynamodbReplicaProviderOnEventHandlerServiceRoleE0E79D6DRef",
             ],
           },
         ],
@@ -938,7 +938,7 @@ exports[`API Global Cloud synthesizes correctly 1`] = `
               {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-0123456789-eu-west-2/736c4e5413d06bda2b68eead1a851838ac6693b2ccdc3bf6a80b1a71fb4c7390.json",
+              "/cdk-hnb659fds-assets-9876543210-eu-west-2/6f05de8bdf8d592bbd69fc718b608036bf603c5db7eeee530173fbf23d8088d8.json",
             ],
           ],
         },
@@ -999,7 +999,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
         },
         "Environment": {
           "Variables": {
-            "DATA_TABLE_NAME": "apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+            "DATA_TABLE_NAME": "apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
           },
         },
         "Handler": "handler",
@@ -1064,7 +1064,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:eu-west-2:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:eu-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1079,7 +1079,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:us-east-1:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:us-east-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1091,7 +1091,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:us-east-2:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:us-east-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1103,7 +1103,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:us-west-1:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:us-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1115,7 +1115,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:us-west-2:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:us-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1127,7 +1127,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:ca-central-1:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:ca-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1139,7 +1139,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:eu-central-1:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:eu-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1151,7 +1151,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:eu-central-2:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:eu-central-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1163,7 +1163,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:eu-north-1:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:eu-north-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1175,7 +1175,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:eu-west-1:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:eu-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1187,7 +1187,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:eu-west-3:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:eu-west-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1199,7 +1199,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:eu-south-1:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:eu-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1211,7 +1211,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:eu-south-2:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:eu-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1223,7 +1223,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:ap-south-1:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:ap-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1235,7 +1235,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:ap-south-2:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:ap-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1247,7 +1247,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:ap-southeast-1:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:ap-southeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1259,7 +1259,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:ap-southeast-2:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:ap-southeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1271,7 +1271,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:ap-southeast-3:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:ap-southeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1283,7 +1283,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:ap-northeast-1:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:ap-northeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1295,7 +1295,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:ap-northeast-2:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:ap-northeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1307,7 +1307,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:ap-northeast-3:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:ap-northeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1319,7 +1319,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:me-central-1:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:me-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1402,7 +1402,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
     },
     "ApiHandlerServiceRoleOverflowPolicy147BA3B1F": {
       "Properties": {
-        "Description": "Part of the policies for APINorthVirginiaDevStack/ApiHandler/ServiceRole",
+        "Description": "Part of the policies for APINorthVirginiaProdStack/ApiHandler/ServiceRole",
         "Path": "/",
         "PolicyDocument": {
           "Statement": [
@@ -1418,7 +1418,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:eu-west-2:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:eu-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1433,7 +1433,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:us-east-1:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:us-east-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1445,7 +1445,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:us-east-2:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:us-east-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1457,7 +1457,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:us-west-1:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:us-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1469,7 +1469,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:us-west-2:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:us-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1481,7 +1481,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:ca-central-1:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:ca-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1493,7 +1493,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:eu-central-1:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:eu-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1505,7 +1505,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:eu-central-2:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:eu-central-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1517,7 +1517,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:eu-north-1:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:eu-north-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1529,7 +1529,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:eu-west-1:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:eu-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1541,7 +1541,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:eu-west-3:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:eu-west-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1553,7 +1553,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:eu-south-1:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:eu-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1565,7 +1565,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:eu-south-2:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:eu-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1577,7 +1577,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:ap-south-1:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:ap-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1589,7 +1589,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:ap-south-2:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:ap-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1601,7 +1601,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:ap-southeast-1:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:ap-southeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1613,7 +1613,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:ap-southeast-2:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:ap-southeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1625,7 +1625,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:ap-southeast-3:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:ap-southeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1637,7 +1637,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:ap-northeast-1:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:ap-northeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1649,7 +1649,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:ap-northeast-2:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:ap-northeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1661,7 +1661,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:ap-northeast-3:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:ap-northeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1673,7 +1673,7 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":dynamodb:me-central-1:0123456789:table/apiglobaldevstackevstackdatatabled8b98642c101a1543054",
+                      ":dynamodb:me-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
                     ],
                   ],
                 },
@@ -1752,6 +1752,9848 @@ exports[`API Global Cloud synthesizes correctly 2`] = `
         ],
       },
       "Type": "AWS::IAM::ManagedPolicy",
+    },
+    "ApiHandlersesSendEmail726F8BB3": {
+      "Properties": {
+        "Action": "ses:SendEmail",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "ApiHandler5E7490E8",
+            "Arn",
+          ],
+        },
+        "Principal": "ses.amazonaws.com",
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+  },
+  "Rules": {
+    "CheckBootstrapVersion": {
+      "Assertions": [
+        {
+          "Assert": {
+            "Fn::Not": [
+              {
+                "Fn::Contains": [
+                  [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`API Global Cloud synthesizes correctly 3`] = `
+{
+  "Parameters": {
+    "BootstrapVersion": {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": {
+    "ApiHandler5E7490E8": {
+      "DependsOn": [
+        "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "ApiHandlerServiceRole592E70E9",
+      ],
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = () => {console.log(process.env.EXAMPLE_TABLE_NAME); return "SUCCESS"}",
+        },
+        "Environment": {
+          "Variables": {
+            "DATA_TABLE_NAME": "apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+          },
+        },
+        "Handler": "handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "ApiHandlerServiceRole592E70E9",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "ApiHandlerServiceRole592E70E9": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ApiHandlerServiceRoleDefaultPolicy10321D87": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "dynamodb:PutItem",
+                "dynamodb:GetItem",
+                "dynamodb:UpdateItem",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ca-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-north-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:me-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "Roles": [
+          {
+            "Ref": "ApiHandlerServiceRole592E70E9",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ApiHandlersesSendEmail726F8BB3": {
+      "Properties": {
+        "Action": "ses:SendEmail",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "ApiHandler5E7490E8",
+            "Arn",
+          ],
+        },
+        "Principal": "ses.amazonaws.com",
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+  },
+  "Rules": {
+    "CheckBootstrapVersion": {
+      "Assertions": [
+        {
+          "Assert": {
+            "Fn::Not": [
+              {
+                "Fn::Contains": [
+                  [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`API Global Cloud synthesizes correctly 4`] = `
+{
+  "Parameters": {
+    "BootstrapVersion": {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": {
+    "ApiHandler5E7490E8": {
+      "DependsOn": [
+        "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "ApiHandlerServiceRole592E70E9",
+      ],
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = () => {console.log(process.env.EXAMPLE_TABLE_NAME); return "SUCCESS"}",
+        },
+        "Environment": {
+          "Variables": {
+            "DATA_TABLE_NAME": "apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+          },
+        },
+        "Handler": "handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "ApiHandlerServiceRole592E70E9",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "ApiHandlerServiceRole592E70E9": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ApiHandlerServiceRoleDefaultPolicy10321D87": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "dynamodb:PutItem",
+                "dynamodb:GetItem",
+                "dynamodb:UpdateItem",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ca-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-north-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:me-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "Roles": [
+          {
+            "Ref": "ApiHandlerServiceRole592E70E9",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ApiHandlersesSendEmail726F8BB3": {
+      "Properties": {
+        "Action": "ses:SendEmail",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "ApiHandler5E7490E8",
+            "Arn",
+          ],
+        },
+        "Principal": "ses.amazonaws.com",
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+  },
+  "Rules": {
+    "CheckBootstrapVersion": {
+      "Assertions": [
+        {
+          "Assert": {
+            "Fn::Not": [
+              {
+                "Fn::Contains": [
+                  [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`API Global Cloud synthesizes correctly 5`] = `
+{
+  "Parameters": {
+    "BootstrapVersion": {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": {
+    "ApiHandler5E7490E8": {
+      "DependsOn": [
+        "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "ApiHandlerServiceRole592E70E9",
+      ],
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = () => {console.log(process.env.EXAMPLE_TABLE_NAME); return "SUCCESS"}",
+        },
+        "Environment": {
+          "Variables": {
+            "DATA_TABLE_NAME": "apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+          },
+        },
+        "Handler": "handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "ApiHandlerServiceRole592E70E9",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "ApiHandlerServiceRole592E70E9": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ApiHandlerServiceRoleDefaultPolicy10321D87": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "dynamodb:PutItem",
+                "dynamodb:GetItem",
+                "dynamodb:UpdateItem",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ca-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-north-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:me-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "Roles": [
+          {
+            "Ref": "ApiHandlerServiceRole592E70E9",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ApiHandlersesSendEmail726F8BB3": {
+      "Properties": {
+        "Action": "ses:SendEmail",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "ApiHandler5E7490E8",
+            "Arn",
+          ],
+        },
+        "Principal": "ses.amazonaws.com",
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+  },
+  "Rules": {
+    "CheckBootstrapVersion": {
+      "Assertions": [
+        {
+          "Assert": {
+            "Fn::Not": [
+              {
+                "Fn::Contains": [
+                  [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`API Global Cloud synthesizes correctly 6`] = `
+{
+  "Parameters": {
+    "BootstrapVersion": {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": {
+    "ApiHandler5E7490E8": {
+      "DependsOn": [
+        "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "ApiHandlerServiceRole592E70E9",
+      ],
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = () => {console.log(process.env.EXAMPLE_TABLE_NAME); return "SUCCESS"}",
+        },
+        "Environment": {
+          "Variables": {
+            "DATA_TABLE_NAME": "apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+          },
+        },
+        "Handler": "handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "ApiHandlerServiceRole592E70E9",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "ApiHandlerServiceRole592E70E9": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ApiHandlerServiceRoleDefaultPolicy10321D87": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "dynamodb:PutItem",
+                "dynamodb:GetItem",
+                "dynamodb:UpdateItem",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ca-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-north-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:me-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "Roles": [
+          {
+            "Ref": "ApiHandlerServiceRole592E70E9",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ApiHandlersesSendEmail726F8BB3": {
+      "Properties": {
+        "Action": "ses:SendEmail",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "ApiHandler5E7490E8",
+            "Arn",
+          ],
+        },
+        "Principal": "ses.amazonaws.com",
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+  },
+  "Rules": {
+    "CheckBootstrapVersion": {
+      "Assertions": [
+        {
+          "Assert": {
+            "Fn::Not": [
+              {
+                "Fn::Contains": [
+                  [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`API Global Cloud synthesizes correctly 7`] = `
+{
+  "Parameters": {
+    "BootstrapVersion": {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": {
+    "ApiHandler5E7490E8": {
+      "DependsOn": [
+        "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "ApiHandlerServiceRole592E70E9",
+      ],
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = () => {console.log(process.env.EXAMPLE_TABLE_NAME); return "SUCCESS"}",
+        },
+        "Environment": {
+          "Variables": {
+            "DATA_TABLE_NAME": "apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+          },
+        },
+        "Handler": "handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "ApiHandlerServiceRole592E70E9",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "ApiHandlerServiceRole592E70E9": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ApiHandlerServiceRoleDefaultPolicy10321D87": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "dynamodb:PutItem",
+                "dynamodb:GetItem",
+                "dynamodb:UpdateItem",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ca-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-north-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:me-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "Roles": [
+          {
+            "Ref": "ApiHandlerServiceRole592E70E9",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ApiHandlersesSendEmail726F8BB3": {
+      "Properties": {
+        "Action": "ses:SendEmail",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "ApiHandler5E7490E8",
+            "Arn",
+          ],
+        },
+        "Principal": "ses.amazonaws.com",
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+  },
+  "Rules": {
+    "CheckBootstrapVersion": {
+      "Assertions": [
+        {
+          "Assert": {
+            "Fn::Not": [
+              {
+                "Fn::Contains": [
+                  [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`API Global Cloud synthesizes correctly 8`] = `
+{
+  "Parameters": {
+    "BootstrapVersion": {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": {
+    "ApiHandler5E7490E8": {
+      "DependsOn": [
+        "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "ApiHandlerServiceRole592E70E9",
+      ],
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = () => {console.log(process.env.EXAMPLE_TABLE_NAME); return "SUCCESS"}",
+        },
+        "Environment": {
+          "Variables": {
+            "DATA_TABLE_NAME": "apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+          },
+        },
+        "Handler": "handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "ApiHandlerServiceRole592E70E9",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "ApiHandlerServiceRole592E70E9": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ApiHandlerServiceRoleDefaultPolicy10321D87": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "dynamodb:PutItem",
+                "dynamodb:GetItem",
+                "dynamodb:UpdateItem",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ca-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-north-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:me-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "Roles": [
+          {
+            "Ref": "ApiHandlerServiceRole592E70E9",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ApiHandlersesSendEmail726F8BB3": {
+      "Properties": {
+        "Action": "ses:SendEmail",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "ApiHandler5E7490E8",
+            "Arn",
+          ],
+        },
+        "Principal": "ses.amazonaws.com",
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+  },
+  "Rules": {
+    "CheckBootstrapVersion": {
+      "Assertions": [
+        {
+          "Assert": {
+            "Fn::Not": [
+              {
+                "Fn::Contains": [
+                  [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`API Global Cloud synthesizes correctly 9`] = `
+{
+  "Parameters": {
+    "BootstrapVersion": {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": {
+    "ApiHandler5E7490E8": {
+      "DependsOn": [
+        "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "ApiHandlerServiceRole592E70E9",
+      ],
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = () => {console.log(process.env.EXAMPLE_TABLE_NAME); return "SUCCESS"}",
+        },
+        "Environment": {
+          "Variables": {
+            "DATA_TABLE_NAME": "apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+          },
+        },
+        "Handler": "handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "ApiHandlerServiceRole592E70E9",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "ApiHandlerServiceRole592E70E9": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ApiHandlerServiceRoleDefaultPolicy10321D87": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "dynamodb:PutItem",
+                "dynamodb:GetItem",
+                "dynamodb:UpdateItem",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ca-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-north-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:me-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "Roles": [
+          {
+            "Ref": "ApiHandlerServiceRole592E70E9",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ApiHandlersesSendEmail726F8BB3": {
+      "Properties": {
+        "Action": "ses:SendEmail",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "ApiHandler5E7490E8",
+            "Arn",
+          ],
+        },
+        "Principal": "ses.amazonaws.com",
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+  },
+  "Rules": {
+    "CheckBootstrapVersion": {
+      "Assertions": [
+        {
+          "Assert": {
+            "Fn::Not": [
+              {
+                "Fn::Contains": [
+                  [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`API Global Cloud synthesizes correctly 10`] = `
+{
+  "Parameters": {
+    "BootstrapVersion": {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": {
+    "ApiHandler5E7490E8": {
+      "DependsOn": [
+        "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "ApiHandlerServiceRole592E70E9",
+      ],
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = () => {console.log(process.env.EXAMPLE_TABLE_NAME); return "SUCCESS"}",
+        },
+        "Environment": {
+          "Variables": {
+            "DATA_TABLE_NAME": "apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+          },
+        },
+        "Handler": "handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "ApiHandlerServiceRole592E70E9",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "ApiHandlerServiceRole592E70E9": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ApiHandlerServiceRoleDefaultPolicy10321D87": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "dynamodb:PutItem",
+                "dynamodb:GetItem",
+                "dynamodb:UpdateItem",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ca-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-north-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:me-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "Roles": [
+          {
+            "Ref": "ApiHandlerServiceRole592E70E9",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ApiHandlersesSendEmail726F8BB3": {
+      "Properties": {
+        "Action": "ses:SendEmail",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "ApiHandler5E7490E8",
+            "Arn",
+          ],
+        },
+        "Principal": "ses.amazonaws.com",
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+  },
+  "Rules": {
+    "CheckBootstrapVersion": {
+      "Assertions": [
+        {
+          "Assert": {
+            "Fn::Not": [
+              {
+                "Fn::Contains": [
+                  [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`API Global Cloud synthesizes correctly 11`] = `
+{
+  "Parameters": {
+    "BootstrapVersion": {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": {
+    "ApiHandler5E7490E8": {
+      "DependsOn": [
+        "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "ApiHandlerServiceRole592E70E9",
+      ],
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = () => {console.log(process.env.EXAMPLE_TABLE_NAME); return "SUCCESS"}",
+        },
+        "Environment": {
+          "Variables": {
+            "DATA_TABLE_NAME": {
+              "Fn::ImportValue": "APIGlobalProdStack:ExportsOutputRefDataTable447BC44E7F3657BE",
+            },
+          },
+        },
+        "Handler": "handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "ApiHandlerServiceRole592E70E9",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "ApiHandlerServiceRole592E70E9": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ApiHandlerServiceRoleDefaultPolicy10321D87": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "dynamodb:PutItem",
+                "dynamodb:GetItem",
+                "dynamodb:UpdateItem",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::ImportValue": "APIGlobalProdStack:ExportsOutputFnGetAttDataTable447BC44EArnA4C585D9",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-1:9876543210:table/",
+                      {
+                        "Fn::ImportValue": "APIGlobalProdStack:ExportsOutputRefDataTable447BC44E7F3657BE",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-2:9876543210:table/",
+                      {
+                        "Fn::ImportValue": "APIGlobalProdStack:ExportsOutputRefDataTable447BC44E7F3657BE",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-1:9876543210:table/",
+                      {
+                        "Fn::ImportValue": "APIGlobalProdStack:ExportsOutputRefDataTable447BC44E7F3657BE",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-2:9876543210:table/",
+                      {
+                        "Fn::ImportValue": "APIGlobalProdStack:ExportsOutputRefDataTable447BC44E7F3657BE",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ca-central-1:9876543210:table/",
+                      {
+                        "Fn::ImportValue": "APIGlobalProdStack:ExportsOutputRefDataTable447BC44E7F3657BE",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-1:9876543210:table/",
+                      {
+                        "Fn::ImportValue": "APIGlobalProdStack:ExportsOutputRefDataTable447BC44E7F3657BE",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-2:9876543210:table/",
+                      {
+                        "Fn::ImportValue": "APIGlobalProdStack:ExportsOutputRefDataTable447BC44E7F3657BE",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-north-1:9876543210:table/",
+                      {
+                        "Fn::ImportValue": "APIGlobalProdStack:ExportsOutputRefDataTable447BC44E7F3657BE",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-1:9876543210:table/",
+                      {
+                        "Fn::ImportValue": "APIGlobalProdStack:ExportsOutputRefDataTable447BC44E7F3657BE",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-3:9876543210:table/",
+                      {
+                        "Fn::ImportValue": "APIGlobalProdStack:ExportsOutputRefDataTable447BC44E7F3657BE",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-1:9876543210:table/",
+                      {
+                        "Fn::ImportValue": "APIGlobalProdStack:ExportsOutputRefDataTable447BC44E7F3657BE",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-2:9876543210:table/",
+                      {
+                        "Fn::ImportValue": "APIGlobalProdStack:ExportsOutputRefDataTable447BC44E7F3657BE",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-1:9876543210:table/",
+                      {
+                        "Fn::ImportValue": "APIGlobalProdStack:ExportsOutputRefDataTable447BC44E7F3657BE",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-2:9876543210:table/",
+                      {
+                        "Fn::ImportValue": "APIGlobalProdStack:ExportsOutputRefDataTable447BC44E7F3657BE",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-1:9876543210:table/",
+                      {
+                        "Fn::ImportValue": "APIGlobalProdStack:ExportsOutputRefDataTable447BC44E7F3657BE",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-2:9876543210:table/",
+                      {
+                        "Fn::ImportValue": "APIGlobalProdStack:ExportsOutputRefDataTable447BC44E7F3657BE",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-3:9876543210:table/",
+                      {
+                        "Fn::ImportValue": "APIGlobalProdStack:ExportsOutputRefDataTable447BC44E7F3657BE",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-1:9876543210:table/",
+                      {
+                        "Fn::ImportValue": "APIGlobalProdStack:ExportsOutputRefDataTable447BC44E7F3657BE",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-2:9876543210:table/",
+                      {
+                        "Fn::ImportValue": "APIGlobalProdStack:ExportsOutputRefDataTable447BC44E7F3657BE",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-3:9876543210:table/",
+                      {
+                        "Fn::ImportValue": "APIGlobalProdStack:ExportsOutputRefDataTable447BC44E7F3657BE",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:me-central-1:9876543210:table/",
+                      {
+                        "Fn::ImportValue": "APIGlobalProdStack:ExportsOutputRefDataTable447BC44E7F3657BE",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "Roles": [
+          {
+            "Ref": "ApiHandlerServiceRole592E70E9",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ApiHandlersesSendEmail726F8BB3": {
+      "Properties": {
+        "Action": "ses:SendEmail",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "ApiHandler5E7490E8",
+            "Arn",
+          ],
+        },
+        "Principal": "ses.amazonaws.com",
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+  },
+  "Rules": {
+    "CheckBootstrapVersion": {
+      "Assertions": [
+        {
+          "Assert": {
+            "Fn::Not": [
+              {
+                "Fn::Contains": [
+                  [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`API Global Cloud synthesizes correctly 12`] = `
+{
+  "Parameters": {
+    "BootstrapVersion": {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": {
+    "ApiHandler5E7490E8": {
+      "DependsOn": [
+        "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "ApiHandlerServiceRole592E70E9",
+      ],
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = () => {console.log(process.env.EXAMPLE_TABLE_NAME); return "SUCCESS"}",
+        },
+        "Environment": {
+          "Variables": {
+            "DATA_TABLE_NAME": "apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+          },
+        },
+        "Handler": "handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "ApiHandlerServiceRole592E70E9",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "ApiHandlerServiceRole592E70E9": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ApiHandlerServiceRoleDefaultPolicy10321D87": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "dynamodb:PutItem",
+                "dynamodb:GetItem",
+                "dynamodb:UpdateItem",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ca-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-north-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:me-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "Roles": [
+          {
+            "Ref": "ApiHandlerServiceRole592E70E9",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ApiHandlersesSendEmail726F8BB3": {
+      "Properties": {
+        "Action": "ses:SendEmail",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "ApiHandler5E7490E8",
+            "Arn",
+          ],
+        },
+        "Principal": "ses.amazonaws.com",
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+  },
+  "Rules": {
+    "CheckBootstrapVersion": {
+      "Assertions": [
+        {
+          "Assert": {
+            "Fn::Not": [
+              {
+                "Fn::Contains": [
+                  [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`API Global Cloud synthesizes correctly 13`] = `
+{
+  "Parameters": {
+    "BootstrapVersion": {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": {
+    "ApiHandler5E7490E8": {
+      "DependsOn": [
+        "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "ApiHandlerServiceRole592E70E9",
+      ],
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = () => {console.log(process.env.EXAMPLE_TABLE_NAME); return "SUCCESS"}",
+        },
+        "Environment": {
+          "Variables": {
+            "DATA_TABLE_NAME": "apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+          },
+        },
+        "Handler": "handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "ApiHandlerServiceRole592E70E9",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "ApiHandlerServiceRole592E70E9": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ApiHandlerServiceRoleDefaultPolicy10321D87": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "dynamodb:PutItem",
+                "dynamodb:GetItem",
+                "dynamodb:UpdateItem",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ca-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-north-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:me-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "Roles": [
+          {
+            "Ref": "ApiHandlerServiceRole592E70E9",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ApiHandlersesSendEmail726F8BB3": {
+      "Properties": {
+        "Action": "ses:SendEmail",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "ApiHandler5E7490E8",
+            "Arn",
+          ],
+        },
+        "Principal": "ses.amazonaws.com",
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+  },
+  "Rules": {
+    "CheckBootstrapVersion": {
+      "Assertions": [
+        {
+          "Assert": {
+            "Fn::Not": [
+              {
+                "Fn::Contains": [
+                  [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`API Global Cloud synthesizes correctly 14`] = `
+{
+  "Parameters": {
+    "BootstrapVersion": {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": {
+    "ApiHandler5E7490E8": {
+      "DependsOn": [
+        "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "ApiHandlerServiceRole592E70E9",
+      ],
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = () => {console.log(process.env.EXAMPLE_TABLE_NAME); return "SUCCESS"}",
+        },
+        "Environment": {
+          "Variables": {
+            "DATA_TABLE_NAME": "apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+          },
+        },
+        "Handler": "handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "ApiHandlerServiceRole592E70E9",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "ApiHandlerServiceRole592E70E9": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ApiHandlerServiceRoleDefaultPolicy10321D87": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "dynamodb:PutItem",
+                "dynamodb:GetItem",
+                "dynamodb:UpdateItem",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ca-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-north-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:me-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "Roles": [
+          {
+            "Ref": "ApiHandlerServiceRole592E70E9",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ApiHandlersesSendEmail726F8BB3": {
+      "Properties": {
+        "Action": "ses:SendEmail",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "ApiHandler5E7490E8",
+            "Arn",
+          ],
+        },
+        "Principal": "ses.amazonaws.com",
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+  },
+  "Rules": {
+    "CheckBootstrapVersion": {
+      "Assertions": [
+        {
+          "Assert": {
+            "Fn::Not": [
+              {
+                "Fn::Contains": [
+                  [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`API Global Cloud synthesizes correctly 15`] = `
+{
+  "Parameters": {
+    "BootstrapVersion": {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": {
+    "ApiHandler5E7490E8": {
+      "DependsOn": [
+        "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "ApiHandlerServiceRole592E70E9",
+      ],
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = () => {console.log(process.env.EXAMPLE_TABLE_NAME); return "SUCCESS"}",
+        },
+        "Environment": {
+          "Variables": {
+            "DATA_TABLE_NAME": "apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+          },
+        },
+        "Handler": "handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "ApiHandlerServiceRole592E70E9",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "ApiHandlerServiceRole592E70E9": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ApiHandlerServiceRoleDefaultPolicy10321D87": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "dynamodb:PutItem",
+                "dynamodb:GetItem",
+                "dynamodb:UpdateItem",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ca-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-north-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:me-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "Roles": [
+          {
+            "Ref": "ApiHandlerServiceRole592E70E9",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ApiHandlersesSendEmail726F8BB3": {
+      "Properties": {
+        "Action": "ses:SendEmail",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "ApiHandler5E7490E8",
+            "Arn",
+          ],
+        },
+        "Principal": "ses.amazonaws.com",
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+  },
+  "Rules": {
+    "CheckBootstrapVersion": {
+      "Assertions": [
+        {
+          "Assert": {
+            "Fn::Not": [
+              {
+                "Fn::Contains": [
+                  [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`API Global Cloud synthesizes correctly 16`] = `
+{
+  "Parameters": {
+    "BootstrapVersion": {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": {
+    "ApiHandler5E7490E8": {
+      "DependsOn": [
+        "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "ApiHandlerServiceRole592E70E9",
+      ],
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = () => {console.log(process.env.EXAMPLE_TABLE_NAME); return "SUCCESS"}",
+        },
+        "Environment": {
+          "Variables": {
+            "DATA_TABLE_NAME": "apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+          },
+        },
+        "Handler": "handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "ApiHandlerServiceRole592E70E9",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "ApiHandlerServiceRole592E70E9": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ApiHandlerServiceRoleDefaultPolicy10321D87": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "dynamodb:PutItem",
+                "dynamodb:GetItem",
+                "dynamodb:UpdateItem",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ca-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-north-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:me-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "Roles": [
+          {
+            "Ref": "ApiHandlerServiceRole592E70E9",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ApiHandlersesSendEmail726F8BB3": {
+      "Properties": {
+        "Action": "ses:SendEmail",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "ApiHandler5E7490E8",
+            "Arn",
+          ],
+        },
+        "Principal": "ses.amazonaws.com",
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+  },
+  "Rules": {
+    "CheckBootstrapVersion": {
+      "Assertions": [
+        {
+          "Assert": {
+            "Fn::Not": [
+              {
+                "Fn::Contains": [
+                  [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`API Global Cloud synthesizes correctly 17`] = `
+{
+  "Parameters": {
+    "BootstrapVersion": {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": {
+    "ApiHandler5E7490E8": {
+      "DependsOn": [
+        "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "ApiHandlerServiceRole592E70E9",
+      ],
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = () => {console.log(process.env.EXAMPLE_TABLE_NAME); return "SUCCESS"}",
+        },
+        "Environment": {
+          "Variables": {
+            "DATA_TABLE_NAME": "apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+          },
+        },
+        "Handler": "handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "ApiHandlerServiceRole592E70E9",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "ApiHandlerServiceRole592E70E9": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ApiHandlerServiceRoleDefaultPolicy10321D87": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "dynamodb:PutItem",
+                "dynamodb:GetItem",
+                "dynamodb:UpdateItem",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ca-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-north-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:me-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "Roles": [
+          {
+            "Ref": "ApiHandlerServiceRole592E70E9",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ApiHandlersesSendEmail726F8BB3": {
+      "Properties": {
+        "Action": "ses:SendEmail",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "ApiHandler5E7490E8",
+            "Arn",
+          ],
+        },
+        "Principal": "ses.amazonaws.com",
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+  },
+  "Rules": {
+    "CheckBootstrapVersion": {
+      "Assertions": [
+        {
+          "Assert": {
+            "Fn::Not": [
+              {
+                "Fn::Contains": [
+                  [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`API Global Cloud synthesizes correctly 18`] = `
+{
+  "Parameters": {
+    "BootstrapVersion": {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": {
+    "ApiHandler5E7490E8": {
+      "DependsOn": [
+        "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "ApiHandlerServiceRole592E70E9",
+      ],
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = () => {console.log(process.env.EXAMPLE_TABLE_NAME); return "SUCCESS"}",
+        },
+        "Environment": {
+          "Variables": {
+            "DATA_TABLE_NAME": "apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+          },
+        },
+        "Handler": "handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "ApiHandlerServiceRole592E70E9",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "ApiHandlerServiceRole592E70E9": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ApiHandlerServiceRoleDefaultPolicy10321D87": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "dynamodb:PutItem",
+                "dynamodb:GetItem",
+                "dynamodb:UpdateItem",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ca-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-north-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:me-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "Roles": [
+          {
+            "Ref": "ApiHandlerServiceRole592E70E9",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ApiHandlersesSendEmail726F8BB3": {
+      "Properties": {
+        "Action": "ses:SendEmail",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "ApiHandler5E7490E8",
+            "Arn",
+          ],
+        },
+        "Principal": "ses.amazonaws.com",
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+  },
+  "Rules": {
+    "CheckBootstrapVersion": {
+      "Assertions": [
+        {
+          "Assert": {
+            "Fn::Not": [
+              {
+                "Fn::Contains": [
+                  [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`API Global Cloud synthesizes correctly 19`] = `
+{
+  "Parameters": {
+    "BootstrapVersion": {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": {
+    "ApiHandler5E7490E8": {
+      "DependsOn": [
+        "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "ApiHandlerServiceRole592E70E9",
+      ],
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = () => {console.log(process.env.EXAMPLE_TABLE_NAME); return "SUCCESS"}",
+        },
+        "Environment": {
+          "Variables": {
+            "DATA_TABLE_NAME": "apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+          },
+        },
+        "Handler": "handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "ApiHandlerServiceRole592E70E9",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "ApiHandlerServiceRole592E70E9": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ApiHandlerServiceRoleDefaultPolicy10321D87": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "dynamodb:PutItem",
+                "dynamodb:GetItem",
+                "dynamodb:UpdateItem",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ca-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-north-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:me-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "Roles": [
+          {
+            "Ref": "ApiHandlerServiceRole592E70E9",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ApiHandlersesSendEmail726F8BB3": {
+      "Properties": {
+        "Action": "ses:SendEmail",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "ApiHandler5E7490E8",
+            "Arn",
+          ],
+        },
+        "Principal": "ses.amazonaws.com",
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+  },
+  "Rules": {
+    "CheckBootstrapVersion": {
+      "Assertions": [
+        {
+          "Assert": {
+            "Fn::Not": [
+              {
+                "Fn::Contains": [
+                  [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`API Global Cloud synthesizes correctly 20`] = `
+{
+  "Parameters": {
+    "BootstrapVersion": {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": {
+    "ApiHandler5E7490E8": {
+      "DependsOn": [
+        "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "ApiHandlerServiceRole592E70E9",
+      ],
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = () => {console.log(process.env.EXAMPLE_TABLE_NAME); return "SUCCESS"}",
+        },
+        "Environment": {
+          "Variables": {
+            "DATA_TABLE_NAME": "apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+          },
+        },
+        "Handler": "handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "ApiHandlerServiceRole592E70E9",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "ApiHandlerServiceRole592E70E9": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ApiHandlerServiceRoleDefaultPolicy10321D87": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "dynamodb:PutItem",
+                "dynamodb:GetItem",
+                "dynamodb:UpdateItem",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ca-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-north-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:me-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "Roles": [
+          {
+            "Ref": "ApiHandlerServiceRole592E70E9",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ApiHandlersesSendEmail726F8BB3": {
+      "Properties": {
+        "Action": "ses:SendEmail",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "ApiHandler5E7490E8",
+            "Arn",
+          ],
+        },
+        "Principal": "ses.amazonaws.com",
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+  },
+  "Rules": {
+    "CheckBootstrapVersion": {
+      "Assertions": [
+        {
+          "Assert": {
+            "Fn::Not": [
+              {
+                "Fn::Contains": [
+                  [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`API Global Cloud synthesizes correctly 21`] = `
+{
+  "Parameters": {
+    "BootstrapVersion": {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": {
+    "ApiHandler5E7490E8": {
+      "DependsOn": [
+        "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "ApiHandlerServiceRole592E70E9",
+      ],
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = () => {console.log(process.env.EXAMPLE_TABLE_NAME); return "SUCCESS"}",
+        },
+        "Environment": {
+          "Variables": {
+            "DATA_TABLE_NAME": "apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+          },
+        },
+        "Handler": "handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "ApiHandlerServiceRole592E70E9",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "ApiHandlerServiceRole592E70E9": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ApiHandlerServiceRoleDefaultPolicy10321D87": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "dynamodb:PutItem",
+                "dynamodb:GetItem",
+                "dynamodb:UpdateItem",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ca-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-north-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:me-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "Roles": [
+          {
+            "Ref": "ApiHandlerServiceRole592E70E9",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ApiHandlersesSendEmail726F8BB3": {
+      "Properties": {
+        "Action": "ses:SendEmail",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "ApiHandler5E7490E8",
+            "Arn",
+          ],
+        },
+        "Principal": "ses.amazonaws.com",
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+  },
+  "Rules": {
+    "CheckBootstrapVersion": {
+      "Assertions": [
+        {
+          "Assert": {
+            "Fn::Not": [
+              {
+                "Fn::Contains": [
+                  [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`API Global Cloud synthesizes correctly 22`] = `
+{
+  "Parameters": {
+    "BootstrapVersion": {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": {
+    "ApiHandler5E7490E8": {
+      "DependsOn": [
+        "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "ApiHandlerServiceRole592E70E9",
+      ],
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = () => {console.log(process.env.EXAMPLE_TABLE_NAME); return "SUCCESS"}",
+        },
+        "Environment": {
+          "Variables": {
+            "DATA_TABLE_NAME": "apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+          },
+        },
+        "Handler": "handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "ApiHandlerServiceRole592E70E9",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "ApiHandlerServiceRole592E70E9": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ApiHandlerServiceRoleDefaultPolicy10321D87": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "dynamodb:PutItem",
+                "dynamodb:GetItem",
+                "dynamodb:UpdateItem",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ca-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-north-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:me-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "Roles": [
+          {
+            "Ref": "ApiHandlerServiceRole592E70E9",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ApiHandlersesSendEmail726F8BB3": {
+      "Properties": {
+        "Action": "ses:SendEmail",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "ApiHandler5E7490E8",
+            "Arn",
+          ],
+        },
+        "Principal": "ses.amazonaws.com",
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+  },
+  "Rules": {
+    "CheckBootstrapVersion": {
+      "Assertions": [
+        {
+          "Assert": {
+            "Fn::Not": [
+              {
+                "Fn::Contains": [
+                  [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`API Global Cloud synthesizes correctly 23`] = `
+{
+  "Parameters": {
+    "BootstrapVersion": {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": {
+    "ApiHandler5E7490E8": {
+      "DependsOn": [
+        "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "ApiHandlerServiceRole592E70E9",
+      ],
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = () => {console.log(process.env.EXAMPLE_TABLE_NAME); return "SUCCESS"}",
+        },
+        "Environment": {
+          "Variables": {
+            "DATA_TABLE_NAME": "apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+          },
+        },
+        "Handler": "handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "ApiHandlerServiceRole592E70E9",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "ApiHandlerServiceRole592E70E9": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ApiHandlerServiceRoleDefaultPolicy10321D87": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "dynamodb:PutItem",
+                "dynamodb:GetItem",
+                "dynamodb:UpdateItem",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-east-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:us-west-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ca-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-central-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-north-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-west-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:eu-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-south-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-southeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-2:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:ap-northeast-3:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":dynamodb:me-central-1:9876543210:table/apiglobalprodstackodstackdatatablea34e91c8db0ca89c705c",
+                    ],
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ApiHandlerServiceRoleDefaultPolicy10321D87",
+        "Roles": [
+          {
+            "Ref": "ApiHandlerServiceRole592E70E9",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "ApiHandlersesSendEmail726F8BB3": {
       "Properties": {

--- a/tests/api-global-cloud.test.ts
+++ b/tests/api-global-cloud.test.ts
@@ -1,22 +1,11 @@
-import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
-
-import { ApiGlobalCloud } from '../examples/multi-region-serverless/api-global-cloud';
-import { Stage } from '../lib';
-
-const app = new cdk.App();
+import { prodAPICloud } from '../examples/multi-region-serverless';
 
 describe('API Global Cloud', () => {
   test('synthesizes correctly', () => {
-    const apiGlobalCloud = new ApiGlobalCloud(
-      app,
-      new Stage('Dev', { account: '0123456789' })
-    );
-
-    const globalTemplate = Template.fromStack(apiGlobalCloud.stacks[0]);
-    const regionalTemplate = Template.fromStack(apiGlobalCloud.stacks[1]);
-
-    expect(globalTemplate.toJSON()).toMatchSnapshot();
-    expect(regionalTemplate.toJSON()).toMatchSnapshot();
+    prodAPICloud.stacks.forEach((stack) => {
+      const template = Template.fromStack(stack);
+      expect(template.toJSON()).toMatchSnapshot();
+    });
   });
 });


### PR DESCRIPTION
Now, a stage can span multiple accounts. This can be useful if a specific region in a Global Cloud is getting high traffic or consuming high resources to trigger account limits for other regions.